### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bytecaretech/bytecaretech.github.io/security/code-scanning/6](https://github.com/bytecaretech/bytecaretech.github.io/security/code-scanning/6)

To fix the issue, add a `permissions` block to the root of the workflow file to apply minimal permissions to all jobs that do not have their own `permissions` block. Alternatively, add a `permissions` block to each individual job (`setup`, `lint`, `test`, and `build`) to specify the least privileges required for each job. Since the `deploy` job already has explicit permissions, no changes are needed for it.

The best approach is to add a `permissions` block at the root level of the workflow file, as this ensures consistency and reduces redundancy. The permissions should be set to `contents: read`, which is the minimal permission required for most workflows.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
